### PR TITLE
Fix bug

### DIFF
--- a/dobot_bringup/include/dobot_bringup/commander.h
+++ b/dobot_bringup/include/dobot_bringup/commander.h
@@ -320,7 +320,7 @@ public:
 
     void realSendCmd(const char* cmd, uint32_t len)
     {
-        move_cmd_tcp_->tcpSend(cmd, strlen(cmd));
+        real_time_tcp_->tcpSend(cmd, strlen(cmd));
     }
 
 private:


### PR DESCRIPTION
Method realSendCmd was never switched from move_cmd_tcp_ (port 30003) to
real_time_tcp_ (port 3004).

Please review, @zhangran @zhangran@dobot.cc 