### PR TITLE
Update gazebo.launch

### DIFF
--- a/dobot_gazebo/launch/gazebo.launch
+++ b/dobot_gazebo/launch/gazebo.launch
@@ -12,6 +12,7 @@
     <arg name="gui" value="true"/>
     <arg name="headless" value="false"/>
     <arg name="debug" value="false"/>
+  </include>
   <node 
      name="urdf_spawner" 
      pkg="gazebo_ros" 


### PR DESCRIPTION
Was unable to pass argument and spawn robot in new world. Fixed the minor error.